### PR TITLE
Support deep fields

### DIFF
--- a/src/Entity/Net/DeepFilters.php
+++ b/src/Entity/Net/DeepFilters.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Extraton\TonClient\Entity\Net;
+
+use Extraton\TonClient\Entity\Net\Filters;
+use Extraton\TonClient\Exception\LogicException;
+
+class DeepFilters extends Filters
+{
+    public function addDeep(array $fields, string $operator, $value): self
+    {
+        $field = reset($fields);
+
+        if (isset($this->filters[$field])) {
+            throw new LogicException(sprintf('Field %s already defined.', $field));
+        }
+
+        $fieldChain = [$operator => $value];
+        foreach (array_reverse($fields) as $newField) {
+            $fieldChain = [
+                $newField => $fieldChain
+            ];
+        }
+
+        $this->filters[$field] = $fieldChain[$field];
+
+        return $this;
+    }
+}

--- a/src/Entity/Net/Filters.php
+++ b/src/Entity/Net/Filters.php
@@ -43,7 +43,7 @@ class Filters implements Params
     ];
 
     /** @var array<string, mixed> */
-    private array $filters = [];
+    protected array $filters = [];
 
     /**
      * @param string $field

--- a/src/Entity/Net/ParamsOfQueryCollection.php
+++ b/src/Entity/Net/ParamsOfQueryCollection.php
@@ -60,4 +60,30 @@ class ParamsOfQueryCollection extends AbstractQuery
             'limit'      => $this->getLimit(),
         ];
     }
+
+    /**
+     * @param string[] $fieldNames
+     * @return $this
+     */
+    public function addDeepResultField(string ...$fieldNames): self
+    {
+        $this->addResultField($this->getRecursiveDeepResultField($fieldNames, 0));
+        return $this;
+    }
+
+    /**
+     * @param string[] $fieldNames
+     * @param int $index
+     * @return string
+     */
+    private function getRecursiveDeepResultField(array $fieldNames, int $index): string
+    {
+        if ($index >= count($fieldNames)) {
+            return '';
+        }
+        $result = $fieldNames[$index];
+        $nextPart = $this->getRecursiveDeepResultField($fieldNames, $index + 1);
+        $nextPart = $nextPart ? "{ {$nextPart} }" : '';
+        return "{$result} {$nextPart}";
+    }
 }


### PR DESCRIPTION
That's more a question than PR as is.
I had to do this to be able to query fields like `a { b { c } }` and to make filters like `a { b { c { eq: 1} } } }`.
Are there things already supported?